### PR TITLE
Fix: add the required "exported" for <activity> to use target SDK greater than 30

### DIFF
--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
             android:icon="@drawable/linkester_ic_link"
             android:label="Linkester"
             android:roundIcon="@drawable/linkester_ic_link"
-            android:theme="@style/linkester_LibTheme">
+            android:theme="@style/linkester_LibTheme"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
I was facing an issue when trying to upgrade an app's SDK version...
I simply added the required line, but wasn't able to sync/build the lib due to missing credentials (for maven publishing I think).
If you can test this and republish if it's working, that would be great.